### PR TITLE
feat: add gh-actions-language-server for GitHub Actions/Workflows

### DIFF
--- a/packages/gh-actions-language-server/zana.yaml
+++ b/packages/gh-actions-language-server/zana.yaml
@@ -1,5 +1,5 @@
 name: gh-actions-language-server
-description: Github Actions Language Server
+description: GitHub Actions Language Server
 homepage: https://github.com/lttb/gh-actions-language-server
 licenses:
   - MIT

--- a/packages/gh-actions-language-server/zana.yaml
+++ b/packages/gh-actions-language-server/zana.yaml
@@ -1,0 +1,13 @@
+name: gh-actions-language-server
+description: Github Actions Language Server
+homepage: https://github.com/lttb/gh-actions-language-server
+licenses:
+  - MIT
+languages:
+  - YAML
+categories:
+  - LSP
+source:
+  id: pkg:npm/gh-actions-language-server
+bin:
+  gh-actions-language-server: npm:gh-actions-language-server


### PR DESCRIPTION
mason-registry is unresponsive https://github.com/mason-org/mason-registry/pull/8497

that's why I am submitting it here

external issue: https://github.com/lttb/gh-actions-language-server/issues/1
